### PR TITLE
Fix attribute name in specification

### DIFF
--- a/benchmark-specification.tex
+++ b/benchmark-specification.tex
@@ -227,7 +227,7 @@ the attributes of Person entity.
         \hline
         speaks & String[1..*]  & The set of languages the person speaks.\\
         \hline
-        browserUser & String  & The browser used by the person when he/she registered to the social network.\\
+        browserUsed & String  & The browser used by the person when he/she registered to the social network.\\
         \hline
         locationIP & String  & The IP of the location from which the person was registered to the social network.\\
         \hline


### PR DESCRIPTION
"Table 2.5: Attributes of Person entity" should contain `browserUsed` attribute according to "Figure 2.1: The LDBC SNB data schema".