### PR TITLE
Renamed delete query indexes to match those of update counterparts

### DIFF
--- a/query-cards/interactive-delete-01.tex
+++ b/query-cards/interactive-delete-01.tex
@@ -9,55 +9,49 @@
 
 \renewcommand{\currentQueryCard}{1}
 \marginpar{
-  \raggedleft
-  \vspace{0.22ex}
+	\raggedleft
+	\vspace{0.22ex}
 
-  \queryRefCard{interactive-delete-01}{ID}{1}\\
-  \queryRefCard{interactive-delete-02}{ID}{2}\\ 
-  \queryRefCard{interactive-delete-03}{ID}{3}\\
-  \queryRefCard{interactive-delete-04}{ID}{4}\\
-  \queryRefCard{interactive-delete-05}{ID}{5}\\
-  \queryRefCard{interactive-delete-06}{ID}{6}\\
-  \queryRefCard{interactive-delete-07}{ID}{7}\\
-  \queryRefCard{interactive-delete-08}{ID}{8}\\
+	\queryRefCard{interactive-delete-01}{ID}{1}\\
+	\queryRefCard{interactive-delete-02}{ID}{2}\\ 
+	\queryRefCard{interactive-delete-03}{ID}{3}\\
+	\queryRefCard{interactive-delete-04}{ID}{4}\\
+	\queryRefCard{interactive-delete-05}{ID}{5}\\
+	\queryRefCard{interactive-delete-06}{ID}{6}\\
+	\queryRefCard{interactive-delete-07}{ID}{7}\\
+	\queryRefCard{interactive-delete-08}{ID}{8}\\
 }
 
 
 \noindent\begin{tabularx}{\queryCardWidth}{|>{\queryPropertyCell}p{\queryPropertyCellWidth}|X|}
-  \hline
-  query & Interactive / delete / 1 \\ \hline
-  % 
-  title & Remove comment like \\ \hline
-  % 
-  % pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
-  % 
-  desc. & Given a \emph{Person} \textbf{node} and a \emph{Comment} \textbf{node}, remove a \emph{likes} edge between them.
-  \\ \hline
-  % 
-  params &
-  \innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
-      $\mathsf{1}$ & Person.id
-      & ID
-      & \texttt{personId}
-      \\ \hline
-      $\mathsf{2}$ & Comment.id
-      & ID
-      & \texttt{commentId}
-      \\ \hline
-    \end{tabularx}}\innerCardVSpace \\ \hline
-  % 
-  comments &
-  \begin{itemize}
-  \item Removal a likes edge is a rare event e.g. people accidently liking a comment, this can be reflected by the relative frequency of the operation.   
-  \end{itemize} 
-  \\ \hline
-  % 
-  % 
-  % 
-  % 
-  % 
+\hline
+query & Interactive / delete / 1 \\ \hline
+%
+title & Remove person \\ \hline
+%
+% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
+%
+desc. & Remove a \emph{Person} \textbf{node} and it's incident \textbf{edges} (\emph{isLocatedIn}, \emph{studyAt}, \emph{workAt}, \emph{hasInterest}, \emph{likes}, \emph{knows}, \emph{hasMember}, \emph{hasModerator}, \emph{hasCreator}). The removal of a \emph{Person} removes all \emph{Forum} they are moderator of and all messages they have posted in other forums. 
+\\ \hline
+%
+params & \innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline $\mathsf{1}$ & Person.id & ID & \texttt{forumId} \\ \hline
+\end{tabularx}}\innerCardVSpace \\ \hline	
+%	
+comments &
+\begin{itemize}
+  \item Removal of a person can (1) remove all associated posts/comments/forum nodes or (2) just the person node. GDPR is a valid argument for (1). Approach (2) could lead to problems with read queries, driver gathering parameters for short reads and inadvertently impose implementation decisions for implementors. 
+\item Removal of a person removes forums of type ``personal walls'' and ``image albums'' not ``groups'', which can continue if even the founder has left the network. The hasModerator edge must transition to an existing person node in the network, two approaches to assigning a new moderator were discussed: (1) choose member at random from the set of existing group members or (2) the member with the oldest group join date becomes the moderator.   
+\item Removal of a person removes all posts/comments they are creator of this could result in the removal of a comment in the middle of a thread. 
+\end{itemize}
+ \\ \hline
+%
+% 
+%
+%
 \end{tabularx}
 \queryCardVSpace
 
 % change \emph back to the old one
 \let\emph\oldemph
+
+

--- a/query-cards/interactive-delete-02.tex
+++ b/query-cards/interactive-delete-02.tex
@@ -7,7 +7,7 @@
 \let\oldemph\emph
 \renewcommand{\emph}[1]{{\footnotesize \sf #1}}
 
-\renewcommand{\currentQueryCard}{2inter}
+\renewcommand{\currentQueryCard}{2}
 \marginpar{
 	\raggedleft
 	\vspace{0.22ex}

--- a/query-cards/interactive-delete-02.tex
+++ b/query-cards/interactive-delete-02.tex
@@ -25,7 +25,7 @@
 
 \noindent\begin{tabularx}{\queryCardWidth}{|>{\queryPropertyCell}p{\queryPropertyCellWidth}|X|}
 	\hline
-	query & Interactive / delete / 1 \\ \hline
+	query & Interactive / delete / 2 \\ \hline
 %
 	title & Remove post like \\ \hline
 %

--- a/query-cards/interactive-delete-03.tex
+++ b/query-cards/interactive-delete-03.tex
@@ -9,51 +9,53 @@
 
 \renewcommand{\currentQueryCard}{3}
 \marginpar{
-	\raggedleft
-	\vspace{0.22ex}
+  \raggedleft
+  \vspace{0.22ex}
 
-	\queryRefCard{interactive-delete-01}{ID}{1}\\
-	\queryRefCard{interactive-delete-02}{ID}{2}\\ 
-	\queryRefCard{interactive-delete-03}{ID}{3}\\
-	\queryRefCard{interactive-delete-04}{ID}{4}\\
-	\queryRefCard{interactive-delete-05}{ID}{5}\\
-	\queryRefCard{interactive-delete-06}{ID}{6}\\
-	\queryRefCard{interactive-delete-07}{ID}{7}\\
-	\queryRefCard{interactive-delete-08}{ID}{8}\\
+  \queryRefCard{interactive-delete-01}{ID}{1}\\
+  \queryRefCard{interactive-delete-02}{ID}{2}\\ 
+  \queryRefCard{interactive-delete-03}{ID}{3}\\
+  \queryRefCard{interactive-delete-04}{ID}{4}\\
+  \queryRefCard{interactive-delete-05}{ID}{5}\\
+  \queryRefCard{interactive-delete-06}{ID}{6}\\
+  \queryRefCard{interactive-delete-07}{ID}{7}\\
+  \queryRefCard{interactive-delete-08}{ID}{8}\\
 }
 
 
 \noindent\begin{tabularx}{\queryCardWidth}{|>{\queryPropertyCell}p{\queryPropertyCellWidth}|X|}
-	\hline
-	query & Interactive / delete / 3 \\ \hline
-%
-	title & Remove friendship \\ \hline
-%
-	% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
-%
-	desc. & Given two \emph{Person} \textbf{nodes}, remove a \emph{knows} edge between them. 
- \\ \hline
-%
-	
-		params &
-		\innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
-		$\mathsf{1}$ & Person.id
- & ID
- & \texttt{person1Id}
- \\ \hline
-		$\mathsf{2}$ & Person.id
- & ID
- & \texttt{person2Id}
- \\ \hline
-		\end{tabularx}}\innerCardVSpace \\ \hline
-	
-%
-	
-%
-	%
-	%
-	%
-	%
+  \hline
+  query & Interactive / delete / 3 \\ \hline
+  % 
+  title & Remove comment like \\ \hline
+  % 
+  % pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
+  % 
+  desc. & Given a \emph{Person} \textbf{node} and a \emph{Comment} \textbf{node}, remove a \emph{likes} edge between them.
+  \\ \hline
+  % 
+  params &
+  \innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
+      $\mathsf{1}$ & Person.id
+      & ID
+      & \texttt{personId}
+      \\ \hline
+      $\mathsf{2}$ & Comment.id
+      & ID
+      & \texttt{commentId}
+      \\ \hline
+    \end{tabularx}}\innerCardVSpace \\ \hline
+  % 
+  comments &
+  \begin{itemize}
+  \item Removal a likes edge is a rare event e.g. people accidently liking a comment, this can be reflected by the relative frequency of the operation.   
+  \end{itemize} 
+  \\ \hline
+  % 
+  % 
+  % 
+  % 
+  % 
 \end{tabularx}
 \queryCardVSpace
 

--- a/query-cards/interactive-delete-04.tex
+++ b/query-cards/interactive-delete-04.tex
@@ -27,11 +27,11 @@
 	\hline
 	query & Interactive / delete / 4 \\ \hline
 %
-	title & Remove forum membership \\ \hline
+	title & Remove forum \\ \hline
 %
 	% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
 %
-	desc. & Given a \emph{Forum} \textbf{node} and a \emph{Person} \textbf{node}, remove a \emph{hasMember} edge between them. 
+	desc. & Remove a \emph{Forum} \textbf{node} and it's incident \textbf{edges} (\emph{hasModerator}, \emph{hasMember}, \emph{hasTag}) and all \emph{Post} in the \emph{Forum} (connected by \emph{containerOf}) and their direct and transitive comments. 
  \\ \hline
 %
 	
@@ -40,10 +40,6 @@
 		$\mathsf{1}$ & Forum.id
  & ID
  & \texttt{forumId}
- \\ \hline
-		$\mathsf{2}$ & Person.id
- & ID
- & \texttt{personId}
  \\ \hline
 		\end{tabularx}}\innerCardVSpace \\ \hline
 	

--- a/query-cards/interactive-delete-05.tex
+++ b/query-cards/interactive-delete-05.tex
@@ -27,19 +27,23 @@
 	\hline
 	query & Interactive / delete / 5 \\ \hline
 %
-	title & Remove comment \\ \hline
+	title & Remove forum membership \\ \hline
 %
 	% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
 %
-	desc. & Remove a \emph{Comment} \textbf{node} and it's incident \textbf{edges} (\emph{isLocatedIn}, \emph{likes}, \emph{hasCreator}, \emph{hasTag}). In addition, remove all replies to the \emph{Comment} connected by \emph{replyOf} and their incident \textbf{edges}. 
+	desc. & Given a \emph{Forum} \textbf{node} and a \emph{Person} \textbf{node}, remove a \emph{hasMember} edge between them. 
  \\ \hline
 %
 	
 		params &
 		\innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
-		$\mathsf{1}$ & Comment.id
+		$\mathsf{1}$ & Forum.id
  & ID
- & \texttt{CommentId}
+ & \texttt{forumId}
+ \\ \hline
+		$\mathsf{2}$ & Person.id
+ & ID
+ & \texttt{personId}
  \\ \hline
 		\end{tabularx}}\innerCardVSpace \\ \hline
 	

--- a/query-cards/interactive-delete-07.tex
+++ b/query-cards/interactive-delete-07.tex
@@ -27,19 +27,19 @@
 	\hline
 	query & Interactive / delete / 7 \\ \hline
 %
-	title & Remove forum \\ \hline
+	title & Remove comment \\ \hline
 %
 	% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
 %
-	desc. & Remove a \emph{Forum} \textbf{node} and it's incident \textbf{edges} (\emph{hasModerator}, \emph{hasMember}, \emph{hasTag}) and all \emph{Post} in the \emph{Forum} (connected by \emph{containerOf}) and their direct and transitive comments. 
+	desc. & Remove a \emph{Comment} \textbf{node} and it's incident \textbf{edges} (\emph{isLocatedIn}, \emph{likes}, \emph{hasCreator}, \emph{hasTag}). In addition, remove all replies to the \emph{Comment} connected by \emph{replyOf} and their incident \textbf{edges}. 
  \\ \hline
 %
 	
 		params &
 		\innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
-		$\mathsf{1}$ & Forum.id
+		$\mathsf{1}$ & Comment.id
  & ID
- & \texttt{forumId}
+ & \texttt{CommentId}
  \\ \hline
 		\end{tabularx}}\innerCardVSpace \\ \hline
 	

--- a/query-cards/interactive-delete-08.tex
+++ b/query-cards/interactive-delete-08.tex
@@ -24,34 +24,38 @@
 
 
 \noindent\begin{tabularx}{\queryCardWidth}{|>{\queryPropertyCell}p{\queryPropertyCellWidth}|X|}
-\hline
-query & Interactive / delete / 8 \\ \hline
+	\hline
+	query & Interactive / delete / 8 \\ \hline
 %
-title & Remove person \\ \hline
+	title & Remove friendship \\ \hline
 %
-% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
+	% pattern & \centering \includegraphics[scale=\patternscale,margin=0cm .2cm]{patterns/interactive-update-01} \tabularnewline \hline
 %
-desc. & Remove a \emph{Person} \textbf{node} and it's incident \textbf{edges} (\emph{isLocatedIn}, \emph{studyAt}, \emph{workAt}, \emph{hasInterest}, \emph{likes}, \emph{knows}, \emph{hasMember}, \emph{hasModerator}, \emph{hasCreator}). The removal of a \emph{Person} removes all \emph{Forum} they are moderator of and all messages they have posted in other forums. 
-\\ \hline
-%
-params & \innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline $\mathsf{1}$ & Person.id & ID & \texttt{forumId} \\ \hline
-\end{tabularx}}\innerCardVSpace \\ \hline	
-%	
-comments &
-\begin{itemize}
-  \item Removal of a person can (1) remove all associated posts/comments/forum nodes or (2) just the person node. GDPR is a valid argument for (1). Approach (2) could lead to problems with read queries, driver gathering parameters for short reads and inadvertently impose implementation decisions for implementors. 
-\item Removal of a person removes forums of type ``personal walls'' and ``image albums'' not ``groups'', which can continue if even the founder has left the network. The hasModerator edge must transition to an existing person node in the network, two approaches to assigning a new moderator were discussed: (1) choose member at random from the set of existing group members or (2) the member with the oldest group join date becomes the moderator.   
-\item Removal of a person removes all posts/comments they are creator of this could result in the removal of a comment in the middle of a thread. 
-\end{itemize}
+	desc. & Given two \emph{Person} \textbf{nodes}, remove a \emph{knows} edge between them. 
  \\ \hline
 %
-% 
+	
+		params &
+		\innerCardVSpace{\begin{tabularx}{\attributeCardWidth}{|>{\paramNumberCell}c|>{\varNameCell}M|>{\typeCell}m{\typeWidth}|Y|} \hline
+		$\mathsf{1}$ & Person.id
+ & ID
+ & \texttt{person1Id}
+ \\ \hline
+		$\mathsf{2}$ & Person.id
+ & ID
+ & \texttt{person2Id}
+ \\ \hline
+		\end{tabularx}}\innerCardVSpace \\ \hline
+	
 %
+	
 %
+	%
+	%
+	%
+	%
 \end{tabularx}
 \queryCardVSpace
 
 % change \emph back to the old one
 \let\emph\oldemph
-
-


### PR DESCRIPTION
I've reordered the ids of the delete queries to match the order of their update counterparts. That is, 
AddPerson is Update1 while RemovePerson is Delete1, AddPostLike is Update2 while RemovePostLike is Delete2 etc.