### PR TITLE
Fix typo in table-csv-basic.tex

### DIFF
--- a/table-csv-basic.tex
+++ b/table-csv-basic.tex
@@ -35,7 +35,7 @@
         E                       & person\_hasInterest\_tag\_*.csv         & Person.id | Tag.id                                                                      \\
         E                       & person\_isLocatedIn\_place\_*.csv       & Person.id | Place.id                                                                    \\
         E                       & person\_knows\_person\_*.csv            & Person.id | Person.id | creationDate                                                    \\
-        E                       & person\_likes\_comment\_*.csv           & Person.id | Post.id | creationDate                                                      \\
+        E                       & person\_likes\_comment\_*.csv           & Person.id | Comment.id | creationDate                                                      \\
         E                       & person\_likes\_post\_*.csv              & Person.id | Post.id | creationDate                                                      \\
         A                       & person\_speaks\_language\_*.csv         & Person.id | language                                                                    \\
         E                       & person\_studyAt\_organisation\_*.csv    & Person.id | Organisation.id | classYear                                                 \\


### PR DESCRIPTION
There is a typo of the description of `person_likes_comment_*.csv`. The `Post.id` should be replaced by `Comment.id`.