### PR TITLE
Change 64-bit Floats to 32-bit Floats in BI

### DIFF
--- a/query-specifications/bi-read-13.yaml
+++ b/query-specifications/bi-read-13.yaml
@@ -29,7 +29,7 @@ result:
     type: 32-bit Integer
     category: aggregated
   - name: zombieScore
-    type: 64-bit Float
+    type: 32-bit Float
     category: aggregated
     description: "Determined as `zombieLikeCount` / `totalLikeCount`"
 sort:

--- a/query-specifications/bi-read-15.yaml
+++ b/query-specifications/bi-read-15.yaml
@@ -33,7 +33,7 @@ result:
     description: Ordered sequence of the *Person* IDs in the path
   - name: weight
     category: calculated
-    type: 64-bit Float
+    type: 32-bit Float
 sort:
   - name: weight
     direction: desc

--- a/query-specifications/bi-read-19.yaml
+++ b/query-specifications/bi-read-19.yaml
@@ -20,7 +20,7 @@ result:
   - name: person2.id
     type: ID
   - name: totalWeight
-    type: 64-bit Float
+    type: 32-bit Float
     category: calculated
 sort:
   - name: totalWeight


### PR DESCRIPTION
Changed 64-bit Floats to 32-bit ones in the BI workload as the extra precision is not required.