### PR TITLE
Fix typo of workload description

### DIFF
--- a/workloads.tex
+++ b/workloads.tex
@@ -40,7 +40,7 @@ We use the following notation:
     \item \textbf{Ordered Tuple}: a fixed-length, fixed-order list of elements, where elements at each position of the tuple have predefined, possibly different, types.
         Surrounded by < and > braces, with the element types between them in a specific order
         \eg \textsf{<String, Boolean>} refers to a 2-tuple containing a string value in the first element and a boolean value in the second,
-        and \textsf{\{<String, Boolean>\}} is an ordered list of those 2-tuples.
+        and \textsf{[<String, Boolean>]} is an ordered list of those 2-tuples.
 \end{itemize}
 
 \paragraph{Categorization of results.}


### PR DESCRIPTION
I found a typo in workload definition, which should be `[<String, Boolean>]` other than `{<String, Boolean>}` since it is described as "an ordered list"